### PR TITLE
Interpret shortcodes within shortcode

### DIFF
--- a/jg-force-full-width-shortcode.php
+++ b/jg-force-full-width-shortcode.php
@@ -9,7 +9,7 @@
  * License: GPL2
  */
 
-//register js script 
+//register js script
 function jg_ffw_script(){
 	wp_register_script( 'jg-force-full-width-shortcode-script', plugins_url( '/js/jg-force-full-width-shortcode.js', __FILE__ ) , array( 'jquery') );
 }
@@ -18,6 +18,8 @@ add_action( 'wp_enqueue_scripts', 'jg_ffw_script' );
 // adding shortcodes functions
 function jg_ffw_shortcode( $atts, $content = null ) {
 	wp_enqueue_script( 'jg-force-full-width-shortcode-script' );
+	// run shortcode parser recursively
+	$content = do_shortcode($content);
 	return '<div class="jg-force-full-width">' . $content . '</div>';
 }
 add_shortcode( 'jg-ffw', 'jg_ffw_shortcode' );


### PR DESCRIPTION
If you have shortcodes within the [jg-ffw] content it wasn’t interpreted.